### PR TITLE
Add restart capability to the fire behavior model

### DIFF
--- a/driver/fire_behavior.F90
+++ b/driver/fire_behavior.F90
@@ -8,15 +8,22 @@
     use initialize_mod, only : Init_fire_state, Init_atm_state
     use advance_mod, only : Advance_state
     use wrfdata_mod, only : wrfdata_t
+    use datetime_mod, only : datetime_t
+    use stderrout_mod, only : Stop_simulation
     use, intrinsic :: iso_fortran_env, only : ERROR_UNIT, OUTPUT_UNIT
 
     implicit none
 
     integer :: ierr, rank, mpi_comm_cfbm
+    integer :: restart_step_interval
+    real :: restart_interval_seconds, restart_interval_error
     type (state_fire_t) :: grid
     type (wrfdata_t) :: atm_state
     type (namelist_t) :: config_flags
+    type (datetime_t) :: datetime_check
+    character (len = 256) :: msg
     logical, parameter :: DEBUG_LOCAL = .false.
+    real, parameter :: RESTART_INTERVAL_TOL = 1.0e-6
 
 
     if (DEBUG_LOCAL) write (OUTPUT_UNIT, *) 'Running fire_behavior...'
@@ -71,14 +78,43 @@
 
     end select
 
-    if (DEBUG_LOCAL) write (OUTPUT_UNIT, *) '  Saving fire state...'
-    call grid%Save_state ()
+    if (config_flags%restart) then
+      if (DEBUG_LOCAL) write (OUTPUT_UNIT, *) '  Reading restart state...'
+      call grid%Read_restart (config_flags)
+
+    else
+      if (DEBUG_LOCAL) write (OUTPUT_UNIT, *) '  Saving fire state...'
+      call grid%Save_state ()
+    end if
+
+    restart_step_interval = -1
+    if (config_flags%restart_interval > 0) then
+      restart_step_interval = nint (real (config_flags%restart_interval) / grid%dt)
+      restart_interval_seconds = restart_step_interval * grid%dt
+      restart_interval_error = abs (restart_interval_seconds - real (config_flags%restart_interval))
+
+      if (restart_step_interval <= 0 .or. &
+          restart_interval_error > max (RESTART_INTERVAL_TOL, abs (real (config_flags%restart_interval)) * RESTART_INTERVAL_TOL)) then
+        write (msg, '(a, i0, a, f12.6)') 'restart_interval must map to an integer number of time steps: restart_interval = ', &
+            config_flags%restart_interval, ', dt = ', grid%dt
+        call Stop_simulation (msg)
+      end if
+    end if
 
     if (DEBUG_LOCAL) write (OUTPUT_UNIT, *) '  Starting temporal loop...'
     do while (grid%datetime_now < grid%datetime_end)
       call Advance_state (grid, config_flags)
+
+      datetime_check = grid%datetime_start
+      call datetime_check%Add_seconds (grid%itimestep * grid%dt)
+      if (datetime_check /= grid%datetime_now) call Stop_simulation ('Model clock is inconsistent with itimestep and dt')
+
       call grid%Handle_output (config_flags)
       if (config_flags%ideal_opt == 0) call grid%Handle_wrfdata_update (atm_state, config_flags)
+
+      if (restart_step_interval > 0) then
+        if (mod (grid%itimestep, restart_step_interval) == 0) call grid%Write_restart (config_flags)
+      end if
     end do
     if (DEBUG_LOCAL) write (OUTPUT_UNIT, *) '  Completed temporal loop'
 

--- a/driver/initialize_mod.F90
+++ b/driver/initialize_mod.F90
@@ -1,10 +1,11 @@
   module initialize_mod
 
-    use state_mod, only : state_fire_t
+    use state_mod, only : state_fire_t, Build_restart_file_name
     use namelist_mod, only : namelist_t
     use geogrid_mod, only : geogrid_t
     use wrfdata_mod, only : wrfdata_t
     use fire_driver_mod, only : Init_fire_components
+    use datetime_mod, only : datetime_t
     use stderrout_mod, only: Print_message, Stop_simulation
 #ifdef DM_PARALLEL
     use mpi_mod, only : Convert_mpi_comm_to_f08
@@ -59,7 +60,11 @@
       if (DEBUG_LOCAL) call Print_message ('  Entering subroutine Init_state')
 
       if (DEBUG_LOCAL) call Print_message ('  Initialization...')
-      if (config_flags%ideal_opt == 0) then
+      if (config_flags%ideal_opt == 0 .and. config_flags%restart) then
+          ! Real world, restart run: the grid metadata comes from the restart file
+        call Init_fire_state_from_restart (grid, config_flags)
+
+      else if (config_flags%ideal_opt == 0) then
           ! Real world
         if (DEBUG_LOCAL) call Print_message ('    Reading geogrid file')
 #ifdef DM_PARALLEL
@@ -110,7 +115,7 @@
 
       call Init_fire_components (grid, config_flags)
 
-      if (present (wrf)) then
+      if (present (wrf) .and. .not. config_flags%restart) then
         if (DEBUG_LOCAL) call Print_message ('    Initializing atmospheric state')
         call grid%Handle_wrfdata_update (wrf, config_flags)
       end if
@@ -142,6 +147,31 @@
       if (DEBUG_LOCAL) call Print_message ('  Leaving subroutine Init_state')
 
     end subroutine Init_fire_state
+
+    subroutine Init_fire_state_from_restart (grid, config_flags)
+
+      implicit none
+
+      type (state_fire_t), intent (in out) :: grid
+      type (namelist_t), intent (in) :: config_flags
+
+      type (datetime_t) :: datetime_restart
+      character (len = :), allocatable :: file_restart
+      logical, parameter :: DEBUG_LOCAL = .false.
+
+
+      if (DEBUG_LOCAL) call Print_message ('  Entering subroutine Init_fire_state_from_restart')
+
+      datetime_restart = datetime_t (config_flags%start_year, config_flags%start_month, config_flags%start_day, &
+          config_flags%start_hour, config_flags%start_minute, config_flags%start_second)
+      file_restart = Build_restart_file_name (datetime_restart%datetime)
+
+      if (DEBUG_LOCAL) call Print_message ('    Initializing fire state from restart metadata')
+      call grid%Initialization (config_flags, restart_file = file_restart)
+
+      if (DEBUG_LOCAL) call Print_message ('  Leaving subroutine Init_fire_state_from_restart')
+
+    end subroutine Init_fire_state_from_restart
 
     subroutine Init_fire_state_within_wrf (state, config_flags, &
         ifds, ifde, ifms, ifme, ifps, ifpe, &
@@ -184,6 +214,8 @@
           nfuel_cat = nfuel_cat, zsf = zsf, dzdxf = dzdxf, dzdyf = dzdyf)
 
       call Init_fire_components (state, config_flags)
+
+      if (config_flags%restart) call state%Read_restart (config_flags)
 
       if (DEBUG_LOCAL) call Print_message ('  Leaving subroutine Init_fire_state_within_wrf...')
 

--- a/io/namelist_mod.F90
+++ b/io/namelist_mod.F90
@@ -38,6 +38,10 @@
       integer :: interval_output = -1         ! Frequency to save the output [s]
       real :: dt = 2.0                        ! Time step of the fire model [s]
 
+        ! Restart controls
+      logical :: restart = .false.            ! Read initial dynamic fire state from fire_restart_<start datetime>.nc
+      integer :: restart_interval = -1        ! Restart output interval [s]; -1 disables restart writes
+
       integer :: num_tiles = 1                ! Number of tiles in each patch
       integer :: tile_strategy = 0            ! Strategy for the tile decomposition: 0) ...
 
@@ -215,6 +219,8 @@
 
       call Broadcast_integer (this%ideal_opt)
       call Broadcast_integer (this%devel_opt)
+      call Broadcast_logical (this%restart)
+      call Broadcast_integer (this%restart_interval)
       call Broadcast_integer (this%fuel_opt)
       call Broadcast_integer (this%ros_opt)
       call Broadcast_integer (this%emis_opt)
@@ -382,6 +388,9 @@
 
       if (this%ideal_opt /= 0 .and. this%fmoist_run) &
           call Stop_simulation ('ideal runs do not support a FMC model')
+
+      if (this%restart_interval /= -1 .and. this%restart_interval <= 0) &
+          call Stop_simulation ('restart_interval must be positive or -1')
 
     end subroutine Check_nml
 
@@ -765,15 +774,16 @@
 
       integer :: start_year, start_month, start_day, start_hour, start_minute, start_second, &
           end_year, end_month, end_day, end_hour, end_minute, end_second, interval_output, &
-          num_tiles, tile_strategy
+          restart_interval, num_tiles, tile_strategy
       real :: dt
+      logical :: restart
 
       character (len = :), allocatable :: msg
       integer :: unit_nml, io_stat
 
       namelist /time/ start_year, start_month, start_day, start_hour, start_minute, start_second, &
           end_year, end_month, end_day, end_hour, end_minute, end_second, dt, interval_output, &
-          num_tiles
+          restart, restart_interval, num_tiles
 
 
         ! Set default values
@@ -791,6 +801,8 @@
       end_second = this%end_second
       dt = this%dt
       interval_output = this%interval_output
+      restart = this%restart
+      restart_interval = this%restart_interval
 
       num_tiles = this%num_tiles
       tile_strategy = this%tile_strategy
@@ -822,6 +834,8 @@
       this%end_second = end_second
       this%dt = dt
       this%interval_output = interval_output
+      this%restart = restart
+      this%restart_interval = restart_interval
 
       this%num_tiles = num_tiles
       this%tile_strategy = tile_strategy

--- a/io/netcdf_mod.F90
+++ b/io/netcdf_mod.F90
@@ -8,8 +8,13 @@
     private
 
     character (len = 2), parameter :: NAME_DIM_X = 'nx', NAME_DIM_Y = 'ny'
-    public :: Get_netcdf_var, Get_netcdf_att, Get_netcdf_dim, Create_netcdf_file, Add_netcdf_dim, Add_netcdf_var, &
-       Is_netcdf_file_present, Is_netcdf_var_present, Add_netcdf_var_mpi, NAME_DIM_X, NAME_DIM_Y
+    public :: Get_netcdf_var, Get_netcdf_att, Get_netcdf_dim, Create_netcdf_file, Add_netcdf_dim, Add_netcdf_var, Add_netcdf_att, &
+       Is_netcdf_file_present, Is_netcdf_var_present, Add_netcdf_var_mpi, Get_netcdf_var_mpi, NAME_DIM_X, NAME_DIM_Y
+
+    interface Add_netcdf_att
+      module procedure Add_netcdf_att_int32
+      module procedure Add_netcdf_att_real32
+    end interface Add_netcdf_att
 
     interface Add_netcdf_var
       module procedure Add_netcdf_var_real32_2d
@@ -18,6 +23,7 @@
 
     interface Add_netcdf_var_mpi
       module procedure Add_netcdf_var_real32_2d_mpi
+      module procedure Add_netcdf_var_real32_3d_mpi
     end interface Add_netcdf_var_mpi
 
     interface Get_netcdf_var
@@ -28,12 +34,95 @@
       module procedure Get_netcdf_var_real32_4d
     end interface Get_netcdf_var
 
+    interface Get_netcdf_var_mpi
+      module procedure Get_netcdf_var_real32_2d_mpi
+      module procedure Get_netcdf_var_real32_3d_mpi
+    end interface Get_netcdf_var_mpi
+
     interface Get_netcdf_att
       module procedure Get_netcdf_att_int32
       module procedure Get_netcdf_att_real32
     end interface Get_netcdf_att
 
   contains
+
+    subroutine Add_netcdf_att_int32 (file_name, var_name, att_name, att_value)
+
+      use netcdf
+
+      use, intrinsic :: iso_fortran_env, only :  INT32
+
+      implicit none
+
+      character (len = *), intent(in) :: file_name, var_name, att_name
+      integer (kind = INT32), intent(in) :: att_value
+
+      integer :: status, ncid, varid
+
+
+      status = nf90_open (trim(file_name), NF90_WRITE, ncid)
+      call Check_status (status)
+
+      status = nf90_redef (ncid)
+      call Check_status (status)
+
+      if (var_name == 'global') then
+        status = nf90_put_att (ncid, NF90_GLOBAL, att_name, att_value)
+        call Check_status (status)
+      else
+        status = nf90_inq_varid (ncid, var_name, varid)
+        call Check_status (status)
+
+        status = nf90_put_att (ncid, varid, att_name, att_value)
+        call Check_status (status)
+      end if
+
+      status = nf90_enddef (ncid)
+      call Check_status (status)
+
+      status = nf90_close (ncid)
+      call Check_status (status)
+
+    end subroutine Add_netcdf_att_int32
+
+    subroutine Add_netcdf_att_real32 (file_name, var_name, att_name, att_value)
+
+      use netcdf
+
+      use, intrinsic :: iso_fortran_env, only :  REAL32
+
+      implicit none
+
+      character (len = *), intent(in) :: file_name, var_name, att_name
+      real (kind = REAL32), intent(in) :: att_value
+
+      integer :: status, ncid, varid
+
+
+      status = nf90_open (trim(file_name), NF90_WRITE, ncid)
+      call Check_status (status)
+
+      status = nf90_redef (ncid)
+      call Check_status (status)
+
+      if (var_name == 'global') then
+        status = nf90_put_att (ncid, NF90_GLOBAL, att_name, att_value)
+        call Check_status (status)
+      else
+        status = nf90_inq_varid (ncid, var_name, varid)
+        call Check_status (status)
+
+        status = nf90_put_att (ncid, varid, att_name, att_value)
+        call Check_status (status)
+      end if
+
+      status = nf90_enddef (ncid)
+      call Check_status (status)
+
+      status = nf90_close (ncid)
+      call Check_status (status)
+
+    end subroutine Add_netcdf_att_real32
 
     subroutine Add_netcdf_dim (file_name, name_dim, val_dim)
 
@@ -147,6 +236,128 @@
 
     end subroutine Add_netcdf_var_real32_2d_mpi
 
+    subroutine Get_netcdf_var_real32_2d_mpi (file_name, cfbm_comm, nx, ny, ifps, ifpe, jfps, jfpe, var_name, var2d_local)
+
+#ifdef DM_PARALLEL
+      use mpi
+#endif
+      implicit none
+
+      character (len = *), intent (in) :: file_name, var_name
+      integer, intent (in) :: cfbm_comm, nx, ny, ifps, ifpe, jfps, jfpe
+      real, dimension(ifps:ifpe, jfps:jfpe), intent (out) :: var2d_local
+
+      real, dimension(:, :), allocatable :: var2d_restart
+      character (len = :), allocatable :: msg
+      integer :: rank, ierr
+      logical, parameter :: DEBUG_LOCAL = .false.
+
+
+      if (DEBUG_LOCAL) call Print_message ('Entering Get_netcdf_var_real32_2d_mpi...')
+
+#ifdef DM_PARALLEL
+      call Mpi_comm_rank (cfbm_comm, rank, ierr)
+      if (ierr /= MPI_SUCCESS) call Stop_simulation ('Problems with Mpi_comm_rank ')
+
+      if (rank == 0) then
+        call Get_netcdf_var (file_name, var_name, var2d_restart)
+        if (size (var2d_restart, 1) /= nx .or. size (var2d_restart, 2) /= ny) then
+          msg = 'Restart variable has unexpected dimensions: '//trim (var_name)
+          call Stop_simulation (msg)
+        end if
+      end if
+
+      call Distribute_global_var2d (cfbm_comm, nx, ny, ifps, ifpe, jfps, jfpe, var2d_restart, var2d_local)
+#else
+      call Get_netcdf_var (file_name, var_name, var2d_restart)
+      if (size (var2d_restart, 1) /= nx .or. size (var2d_restart, 2) /= ny) then
+        msg = 'Restart variable has unexpected dimensions: '//trim (var_name)
+        call Stop_simulation (msg)
+      end if
+      var2d_local(1:nx, 1:ny) = var2d_restart(1:nx, 1:ny)
+#endif
+
+      if (allocated (var2d_restart)) deallocate (var2d_restart)
+
+      if (DEBUG_LOCAL) call Print_message ('Leaving Get_netcdf_var_real32_2d_mpi...')
+
+    end subroutine Get_netcdf_var_real32_2d_mpi
+
+    subroutine Distribute_global_var2d (cfbm_comm, nx, ny, ifps, ifpe, jfps, jfpe, var2d_global, var2d_local)
+
+#ifdef DM_PARALLEL
+      use mpi
+#endif
+      implicit none
+
+      integer, intent (in) :: cfbm_comm, nx, ny, ifps, ifpe, jfps, jfpe
+      real, dimension(:, :), allocatable, intent (in out) :: var2d_global
+      real, dimension(ifps:ifpe, jfps:jfpe), intent (out) :: var2d_local
+
+      integer :: i, ierr, j, kbuf, nprocs, nx_local, ny_local, r, rank
+      integer, dimension(:), allocatable :: all_ifps, all_ifpe, all_jfps, all_jfpe, displs, sendcounts
+      real, dimension(:), allocatable :: sendbuf
+
+
+#ifdef DM_PARALLEL
+      call Mpi_comm_rank (cfbm_comm, rank, ierr)
+      if (ierr /= MPI_SUCCESS) call Stop_simulation ('Problems with Mpi_comm_rank ')
+      call Mpi_comm_size (cfbm_comm, nprocs, ierr)
+      if (ierr /= MPI_SUCCESS) call Stop_simulation ('Problems getting the number of MPI tasks')
+
+      nx_local = ifpe - ifps + 1
+      ny_local = jfpe - jfps + 1
+
+      if (rank == 0) then
+        allocate (all_ifps(nprocs), all_ifpe(nprocs), all_jfps(nprocs), all_jfpe(nprocs))
+      else
+        allocate (all_ifps(1), all_ifpe(1), all_jfps(1), all_jfpe(1))
+      end if
+
+      call MPI_Gather (ifps, 1, MPI_INTEGER, all_ifps, 1, MPI_INTEGER, 0, cfbm_comm, ierr)
+      if (ierr /= MPI_SUCCESS) call Stop_simulation ('Problems with MPI_Gather for restart ifps')
+      call MPI_Gather (ifpe, 1, MPI_INTEGER, all_ifpe, 1, MPI_INTEGER, 0, cfbm_comm, ierr)
+      if (ierr /= MPI_SUCCESS) call Stop_simulation ('Problems with MPI_Gather for restart ifpe')
+      call MPI_Gather (jfps, 1, MPI_INTEGER, all_jfps, 1, MPI_INTEGER, 0, cfbm_comm, ierr)
+      if (ierr /= MPI_SUCCESS) call Stop_simulation ('Problems with MPI_Gather for restart jfps')
+      call MPI_Gather (jfpe, 1, MPI_INTEGER, all_jfpe, 1, MPI_INTEGER, 0, cfbm_comm, ierr)
+      if (ierr /= MPI_SUCCESS) call Stop_simulation ('Problems with MPI_Gather for restart jfpe')
+
+      if (rank == 0) then
+        allocate (sendcounts(nprocs), displs(nprocs))
+        do r = 1, nprocs
+          sendcounts(r) = (all_ifpe(r) - all_ifps(r) + 1) * (all_jfpe(r) - all_jfps(r) + 1)
+        end do
+
+        displs(1) = 0
+        do r = 2, nprocs
+          displs(r) = displs(r - 1) + sendcounts(r - 1)
+        end do
+
+        allocate (sendbuf(sum (sendcounts)))
+        kbuf = 0
+        do r = 1, nprocs
+          do j = all_jfps(r), all_jfpe(r)
+            do i = all_ifps(r), all_ifpe(r)
+              kbuf = kbuf + 1
+              sendbuf(kbuf) = var2d_global(i, j)
+            end do
+          end do
+        end do
+      else
+        allocate (sendcounts(1), displs(1), sendbuf(1))
+      end if
+
+      call MPI_Scatterv (sendbuf, sendcounts, displs, MPI_REAL, var2d_local, nx_local * ny_local, MPI_REAL, 0, cfbm_comm, ierr)
+      if (ierr /= MPI_SUCCESS) call Stop_simulation ('Problems with MPI_Scatterv for restart variable')
+
+      deallocate (all_ifps, all_ifpe, all_jfps, all_jfpe, sendcounts, displs, sendbuf)
+#else
+      var2d_local(1:nx, 1:ny) = var2d_global(1:nx, 1:ny)
+#endif
+
+    end subroutine Distribute_global_var2d
+
     subroutine Add_netcdf_var_real32_3d (file_name, name_dims, varname, var)
 
       use netcdf
@@ -189,6 +400,104 @@
       call Check_status (status)
 
     end subroutine Add_netcdf_var_real32_3d
+
+    subroutine Add_netcdf_var_real32_3d_mpi (file_name, name_dims, cfbm_comm, nx, ny, n2, ifps, ifpe, jfps, jfpe, varname, var3d_local)
+
+#ifdef DM_PARALLEL
+      use mpi
+#endif
+      implicit none
+
+      character (len = *), intent (in) :: file_name, varname
+      character (len = *), dimension(:), intent (in) :: name_dims
+      integer, intent (in) :: cfbm_comm, nx, ny, n2, ifps, ifpe, jfps, jfpe
+      real, dimension(ifps:ifpe, n2, jfps:jfpe), intent (in) :: var3d_local
+
+      real, dimension(ifps:ifpe, jfps:jfpe) :: var2d_local
+      real, dimension(nx, ny) :: var2d_global
+      real, dimension(:, :, :), allocatable :: var3d_global
+      integer :: rank, ierr, k
+      logical, parameter :: DEBUG_LOCAL = .false.
+
+
+      if (DEBUG_LOCAL) call Print_message ('Entering Add_netcdf_var_real32_3d_mpi...')
+
+#ifdef DM_PARALLEL
+      call Mpi_comm_rank (cfbm_comm, rank, ierr)
+      if (ierr /= MPI_SUCCESS) call Stop_simulation ('Problems with Mpi_comm_rank ')
+
+      if (rank == 0) allocate (var3d_global(nx, n2, ny))
+      do k = 1, n2
+        var2d_local(ifps:ifpe, jfps:jfpe) = var3d_local(ifps:ifpe, k, jfps:jfpe)
+        call Gather_var2d (cfbm_comm, nx, ny, ifps, ifpe, jfps, jfpe, var2d_local, var2d_global)
+        if (rank == 0) var3d_global(1:nx, k, 1:ny) = var2d_global(1:nx, 1:ny)
+      end do
+
+      if (rank == 0) call Add_netcdf_var (file_name, name_dims, varname, var3d_global)
+#else
+      call Add_netcdf_var (file_name, name_dims, varname, var3d_local(1:nx, 1:n2, 1:ny))
+#endif
+
+      if (allocated (var3d_global)) deallocate (var3d_global)
+
+      if (DEBUG_LOCAL) call Print_message ('Leaving Add_netcdf_var_real32_3d_mpi...')
+
+    end subroutine Add_netcdf_var_real32_3d_mpi
+
+    subroutine Get_netcdf_var_real32_3d_mpi (file_name, cfbm_comm, nx, ny, n2, ifps, ifpe, jfps, jfpe, var_name, var3d_local)
+
+#ifdef DM_PARALLEL
+      use mpi
+#endif
+      implicit none
+
+      character (len = *), intent (in) :: file_name, var_name
+      integer, intent (in) :: cfbm_comm, nx, ny, n2, ifps, ifpe, jfps, jfpe
+      real, dimension(ifps:ifpe, n2, jfps:jfpe), intent (out) :: var3d_local
+
+      real, dimension(:, :), allocatable :: var2d_restart
+      real, dimension(:, :, :), allocatable :: var3d_restart
+      character (len = :), allocatable :: msg
+      integer :: rank, ierr, k
+      logical, parameter :: DEBUG_LOCAL = .false.
+
+
+      if (DEBUG_LOCAL) call Print_message ('Entering Get_netcdf_var_real32_3d_mpi...')
+
+#ifdef DM_PARALLEL
+      call Mpi_comm_rank (cfbm_comm, rank, ierr)
+      if (ierr /= MPI_SUCCESS) call Stop_simulation ('Problems with Mpi_comm_rank ')
+
+      if (rank == 0) then
+        call Get_netcdf_var (file_name, var_name, var3d_restart)
+        if (size (var3d_restart, 1) /= nx .or. size (var3d_restart, 2) /= n2 .or. size (var3d_restart, 3) /= ny) then
+          msg = 'Restart variable has unexpected dimensions: '//trim (var_name)
+          call Stop_simulation (msg)
+        end if
+      end if
+
+      do k = 1, n2
+        if (rank == 0) then
+          allocate (var2d_restart(nx, ny))
+          var2d_restart(1:nx, 1:ny) = var3d_restart(1:nx, k, 1:ny)
+        end if
+        call Distribute_global_var2d (cfbm_comm, nx, ny, ifps, ifpe, jfps, jfpe, var2d_restart, var3d_local(ifps:ifpe, k, jfps:jfpe))
+        if (allocated (var2d_restart)) deallocate (var2d_restart)
+      end do
+#else
+      call Get_netcdf_var (file_name, var_name, var3d_restart)
+      if (size (var3d_restart, 1) /= nx .or. size (var3d_restart, 2) /= n2 .or. size (var3d_restart, 3) /= ny) then
+        msg = 'Restart variable has unexpected dimensions: '//trim (var_name)
+        call Stop_simulation (msg)
+      end if
+      var3d_local(1:nx, 1:n2, 1:ny) = var3d_restart(1:nx, 1:n2, 1:ny)
+#endif
+
+      if (allocated (var3d_restart)) deallocate (var3d_restart)
+
+      if (DEBUG_LOCAL) call Print_message ('Leaving Get_netcdf_var_real32_3d_mpi...')
+
+    end subroutine Get_netcdf_var_real32_3d_mpi
 
 
     subroutine Check_status (status)

--- a/physics/fmc_wrffire_mod.F90
+++ b/physics/fmc_wrffire_mod.F90
@@ -15,8 +15,6 @@
 
     use stderrout_mod, only : Stop_simulation
     use ros_mod, only : ros_t
-    use state_mod, only: state_fire_t
-    use namelist_mod, only : namelist_t
     use fmc_mod, only : fmc_t
     use fuel_mod, only : fuel_t
 

--- a/state/state_mod.F90
+++ b/state/state_mod.F90
@@ -6,25 +6,34 @@
     use constants_mod, only : PI
     use datetime_mod, only : datetime_t
     use fmc_mod, only : fmc_t
+    use fmc_wrffire_mod, only : fmc_wrffire_t
     use fuel_mod, only : fuel_t, FUEL_ANDERSON, Crosswalk_from_scottburgan_to_anderson
     use geogrid_mod, only : geogrid_t
     use ignition_line_mod, only : ignition_line_t
     use namelist_mod, only : namelist_t
-    use netcdf_mod, only : Create_netcdf_file, Add_netcdf_dim, Add_netcdf_var, Add_netcdf_var_mpi, NAME_DIM_X, NAME_DIM_Y
+    use netcdf_mod, only : Create_netcdf_file, Add_netcdf_att, Add_netcdf_dim, Add_netcdf_var_mpi, Get_netcdf_att, &
+        Get_netcdf_var_mpi, Is_netcdf_file_present, NAME_DIM_X, NAME_DIM_Y
     use proj_lc_mod, only : proj_lc_t
     use ros_mod, only : ros_t
     use stderrout_mod, only : Stop_simulation, Print_message
     use tiles_mod, only : Calc_tiles_dims
     use wrfdata_mod, only : wrfdata_t, G, RERADIUS
-    use mpi_mod, only : Calc_tasks_in_x_and_y, Calc_patch_dims, Distribute_var2d, Print_cart_info, topology_dim_order
+    use mpi_mod, only : Calc_tasks_in_x_and_y, Calc_patch_dims, Distribute_var2d, Do_halo_exchange_with_corners, &
+        Print_cart_info, topology_dim_order
+    use, intrinsic :: iso_fortran_env, only : INT32, REAL32
 
     implicit none
 
     private
 
-    public :: state_fire_t, N_POINTS_IN_HALO
+    public :: state_fire_t, N_POINTS_IN_HALO, Build_restart_file_name
 
     integer, parameter :: N_POINTS_IN_HALO = 5, N_DIMS = 2
+    integer, parameter :: RESTART_IO_ROOT = 0
+    character (len = *), parameter :: NAME_DIM_MOISTURE_CLASS = 'moisture_class'
+    character (len = *), parameter :: NAME_VAR_FMC_GC = 'fmc_gc'
+    character (len = *), parameter :: NAME_ATT_FMOIST_LASTTIME = 'fmc_fmoist_lasttime'
+    character (len = *), parameter :: NAME_ATT_FMOIST_NEXTTIME = 'fmc_fmoist_nexttime'
     logical, dimension(2), parameter :: PERIODS = [ .false., .false. ]
     logical, parameter :: REORDER = .true. ! Allow MPI recording tasks for performance
 
@@ -129,10 +138,12 @@
       procedure :: Interpolate_vars_atm_to_fire => Interpolate_vars_atm_to_fire
       procedure, public :: Print => Print_domain ! private
       procedure, public :: Print_tiles => Print_tiles
+      procedure, public :: Read_restart => Read_restart
       procedure, public :: Save_state => Save_state
       procedure, public :: Set_vars_to_default => Set_vars_to_default
       procedure, public :: Set_mpi_comm_cfbm => Set_mpi_comm_cfbm
       procedure, public :: Set_time_stamps => Set_time_stamps
+      procedure, public :: Write_restart => Write_restart
     end type state_fire_t
 
   contains
@@ -302,7 +313,7 @@
                             kfds, kfde, kfms, kfme, kfps, kfpe, &
                             kfts, kfte, ide, jde, &
                             cen_lat, cen_lon, truelat1, truelat2, stand_lon, &
-                            dx, dy, sr_x, sr_y, nfuel_cat, zsf, dzdxf, dzdyf)
+                            dx, dy, sr_x, sr_y, nfuel_cat, zsf, dzdxf, dzdyf, restart_file)
 
 
       implicit none
@@ -310,6 +321,7 @@
       class (state_fire_t), intent(in out) :: this
       type (namelist_t), intent (in) :: config_flags
       type (geogrid_t), intent (in out), optional :: geogrid
+      character (len = *), intent (in), optional :: restart_file
       integer, intent (in), optional :: ifds, ifde, ifms, ifme, ifps, ifpe, &
                                         jfds, jfde, jfms, jfme, jfps, jfpe, &
                                         kfds, kfde, kfms, kfme, kfps, kfpe, &
@@ -317,10 +329,15 @@
       real, intent (in), optional :: cen_lat, cen_lon, truelat1, truelat2, stand_lon, dx, dy
       real, dimension(:, :), intent (in), optional :: nfuel_cat, zsf, dzdxf, dzdyf
 
-      integer, parameter :: INIT_MODE_NONE = 0, INIT_MODE_GEOGRID = 1, INIT_MODE_WRF = 2, INIT_MODE_IDEAL = 3
+      integer, parameter :: INIT_MODE_NONE = 0, INIT_MODE_GEOGRID = 1, INIT_MODE_WRF = 2, INIT_MODE_IDEAL = 3, INIT_MODE_RESTART = 4
       type (proj_lc_t) :: proj
       logical, parameter :: DEBUG_LOCAL = .false.
-      integer :: ids0, ide0, jds0, jde0, i, j, init_mode, px, py, ntasks, ierr, cart_comm, rank, ips, ipe, jps, jpe, is_lfn_init_allocated
+      integer :: ids0, ide0, jds0, jde0, i, j, init_mode, px, py, ntasks, ierr, cart_comm, rank, ips, ipe, jps, jpe, &
+          is_lfn_init_allocated, restart_nx, restart_ny
+      integer :: restart_map_proj, restart_sr_x, restart_sr_y
+      integer (kind = INT32) :: att_int32
+      real (kind = REAL32) :: att_real32
+      real :: restart_dx, restart_dy, restart_cen_lat, restart_cen_lon, restart_stand_lon, restart_true_lat_1, restart_true_lat_2
       integer, dimension(2) :: coords
       character (len = 300) :: msg
 
@@ -330,6 +347,7 @@
       init_mode = INIT_MODE_NONE
       if (config_flags%ideal_opt == 1) init_mode = INIT_MODE_IDEAL
       if (present (geogrid)) init_mode = INIT_MODE_GEOGRID
+      if (present (restart_file)) init_mode = INIT_MODE_RESTART
       if (present (ifds) .and. present (ifde) .and. present (ifms) .and. present (ifme) .and. present (ifps) .and. present (ifpe) .and. &
           present (jfds) .and. present (jfde) .and. present (jfms) .and. present (jfme) .and. present (jfps) .and. present (jfpe) .and. &
           present (kfds) .and. present (kfde) .and. present (kfms) .and. present (kfme) .and. present (kfps) .and. present (kfpe) .and. &
@@ -345,7 +363,7 @@
         ! Set dimensions
       if (DEBUG_LOCAL) call Print_message ('  Setting dimensions...')
       Set_dims: select case (init_mode)
-        case (INIT_MODE_GEOGRID, INIT_MODE_IDEAL)
+        case (INIT_MODE_GEOGRID, INIT_MODE_IDEAL, INIT_MODE_RESTART)
 
           if (init_mode == INIT_MODE_GEOGRID) then
 
@@ -434,6 +452,54 @@
 
             call Calc_patch_dims (config_flags%nx, config_flags%ny, this%px, this%py, coords, ips, ipe, jps, jpe)
 
+#else
+            ips = ids0
+            ipe = ide0
+            jps = jds0
+            jpe = jde0
+#endif
+          else if (init_mode == INIT_MODE_RESTART) then
+
+            restart_nx = 0
+            restart_ny = 0
+            if (Is_restart_io_root (this)) then
+              call Get_netcdf_att (trim (restart_file), 'global', 'nx', att_int32)
+              restart_nx = att_int32
+              call Get_netcdf_att (trim (restart_file), 'global', 'ny', att_int32)
+              restart_ny = att_int32
+            end if
+            call Broadcast_restart_integer (this, restart_nx)
+            call Broadcast_restart_integer (this, restart_ny)
+
+            ids0 = 1
+            ide0 = restart_nx
+            jds0 = 1
+            jde0 = restart_ny
+
+#ifdef DM_PARALLEL
+            if (.not. this%is_cfbm_comm_set) call Stop_simulation ('The MPI CFBM communicator has not been set')
+
+            call Mpi_comm_size (this%cfbm_comm, ntasks, ierr)
+            if (ierr /= MPI_SUCCESS) call Stop_simulation ('Problems getting the number of MPI tasks')
+            this%ntasks = ntasks
+
+            call Calc_tasks_in_x_and_y (this%ntasks, restart_nx, restart_ny, px, py)
+            this%px = px
+            this%py = py
+            write (msg, '(a25, 2(1x, i5))') 'MPI TASKS in x and y =', this%px, this%py
+            call Print_message (msg)
+
+            call Mpi_cart_create (this%cfbm_comm, N_DIMS, [this%px, this%py], PERIODS, REORDER, cart_comm, ierr)
+            if (ierr /= MPI_SUCCESS) call Stop_simulation ('Problems with Mpi_cart_create')
+            this%cart_comm = cart_comm
+
+            call Mpi_comm_rank (this%cart_comm, rank, ierr)
+            if (ierr /= MPI_SUCCESS) call Stop_simulation ('Problems with Mpi_comm_rank ')
+
+            call Mpi_cart_coords (this%cart_comm, rank, N_DIMS, coords, ierr)
+            if (ierr /= MPI_SUCCESS) call Stop_simulation ('Problems with Mpi_cart_coords')
+
+            call Calc_patch_dims (restart_nx, restart_ny, this%px, this%py, coords, ips, ipe, jps, jpe)
 #else
             ips = ids0
             ipe = ide0
@@ -563,6 +629,73 @@
 
           call this%Init_latlons (proj)
 
+        case (INIT_MODE_RESTART)
+          restart_dx = 0.0
+          restart_dy = 0.0
+          restart_map_proj = 0
+          restart_sr_x = 0
+          restart_sr_y = 0
+          restart_cen_lat = 0.0
+          restart_cen_lon = 0.0
+          restart_stand_lon = 0.0
+          restart_true_lat_1 = 0.0
+          restart_true_lat_2 = 0.0
+
+          if (Is_restart_io_root (this)) then
+            call Get_netcdf_att (trim (restart_file), 'global', 'dx', att_real32)
+            restart_dx = att_real32
+            call Get_netcdf_att (trim (restart_file), 'global', 'dy', att_real32)
+            restart_dy = att_real32
+            call Get_netcdf_att (trim (restart_file), 'global', 'map_proj', att_int32)
+            restart_map_proj = att_int32
+            call Get_netcdf_att (trim (restart_file), 'global', 'sr_x', att_int32)
+            restart_sr_x = att_int32
+            call Get_netcdf_att (trim (restart_file), 'global', 'sr_y', att_int32)
+            restart_sr_y = att_int32
+            call Get_netcdf_att (trim (restart_file), 'global', 'cen_lat', att_real32)
+            restart_cen_lat = att_real32
+            call Get_netcdf_att (trim (restart_file), 'global', 'cen_lon', att_real32)
+            restart_cen_lon = att_real32
+            call Get_netcdf_att (trim (restart_file), 'global', 'stand_lon', att_real32)
+            restart_stand_lon = att_real32
+            call Get_netcdf_att (trim (restart_file), 'global', 'true_lat_1', att_real32)
+            restart_true_lat_1 = att_real32
+            call Get_netcdf_att (trim (restart_file), 'global', 'true_lat_2', att_real32)
+            restart_true_lat_2 = att_real32
+          end if
+
+          call Broadcast_restart_real (this, restart_dx)
+          call Broadcast_restart_real (this, restart_dy)
+          call Broadcast_restart_integer (this, restart_map_proj)
+          call Broadcast_restart_integer (this, restart_sr_x)
+          call Broadcast_restart_integer (this, restart_sr_y)
+          call Broadcast_restart_real (this, restart_cen_lat)
+          call Broadcast_restart_real (this, restart_cen_lon)
+          call Broadcast_restart_real (this, restart_stand_lon)
+          call Broadcast_restart_real (this, restart_true_lat_1)
+          call Broadcast_restart_real (this, restart_true_lat_2)
+
+          this%dx = restart_dx
+          this%dy = restart_dy
+
+          if (restart_map_proj /= 1) call Stop_simulation ('Restart map projection is not supported')
+
+          if (restart_sr_x <= 0 .or. restart_sr_y <= 0) call Stop_simulation ('Restart subgrid ratios must be positive')
+          if (mod (this%nx, restart_sr_x) /= 0 .or. mod (this%ny, restart_sr_y) /= 0) &
+              call Stop_simulation ('Restart subgrid ratios do not divide fire-grid dimensions')
+          if (this%nx / restart_sr_x <= 1 .or. this%ny / restart_sr_y <= 1) &
+              call Stop_simulation ('Restart subgrid ratios imply invalid atmospheric dimensions')
+
+          this%cen_lat = restart_cen_lat
+          this%cen_lon = restart_cen_lon
+
+          proj = proj_lc_t (cen_lat = this%cen_lat , cen_lon = this%cen_lon, dx = this%dx * restart_sr_x, &
+              dy = this%dy * restart_sr_y, &
+              standard_lon = restart_stand_lon, true_lat_1 = restart_true_lat_1, &
+              true_lat_2 = restart_true_lat_2, nx = this%nx / restart_sr_x - 1, ny = this%ny / restart_sr_y - 1)
+
+          call this%Init_latlons (proj, srx = restart_sr_x, sry = restart_sr_y)
+
         case default
           call Stop_simulation ('Not ready to complete fire state initialization 2')
 
@@ -613,12 +746,24 @@
           if (config_flags%fire_is_real_perim) &
               call Stop_simulation ('Not ready to initialize from fire perimeter in idealized mode')
 
+        case (INIT_MODE_RESTART)
+          call Read_restart_field_2d (trim (restart_file), 'zsf', this%nx, this%ny, &
+              this%ifms, this%ifme, this%jfms, this%jfme, this%ifps, this%ifpe, this%jfps, this%jfpe, this%cfbm_comm, this%zsf)
+          call Read_restart_field_2d (trim (restart_file), 'dzdxf', this%nx, this%ny, &
+              this%ifms, this%ifme, this%jfms, this%jfme, this%ifps, this%ifpe, this%jfps, this%jfpe, this%cfbm_comm, this%dzdxf)
+          call Read_restart_field_2d (trim (restart_file), 'dzdyf', this%nx, this%ny, &
+              this%ifms, this%ifme, this%jfms, this%jfme, this%ifps, this%ifpe, this%jfps, this%jfpe, this%cfbm_comm, this%dzdyf)
+          call Read_restart_field_2d (trim (restart_file), 'nfuel_cat', this%nx, this%ny, &
+              this%ifms, this%ifme, this%jfms, this%jfme, this%ifps, this%ifpe, this%jfps, this%jfpe, this%cfbm_comm, this%nfuel_cat)
+          call Read_restart_field_2d (trim (restart_file), 'fz0', this%nx, this%ny, &
+              this%ifms, this%ifme, this%jfms, this%jfme, this%ifps, this%ifpe, this%jfps, this%jfpe, this%cfbm_comm, this%fz0)
+
         case default
           call Stop_simulation ('Not ready to complete fire state initialization 3')
 
       end select Set_topo_fuels
 
-      if (config_flags%fuel_opt == FUEL_ANDERSON) call this%Convert_sb_to_ander ()
+      if (config_flags%fuel_opt == FUEL_ANDERSON .and. init_mode /= INIT_MODE_RESTART) call this%Convert_sb_to_ander ()
 
         ! Set clock
       if (DEBUG_LOCAL) call Print_message ('  Setting clock...')
@@ -893,6 +1038,764 @@
       end do
 
     end subroutine Print_tiles
+
+    function Build_restart_file_name (restart_datetime) result (file_restart)
+
+      implicit none
+
+      character (len = *), intent (in) :: restart_datetime
+
+      character (len = :), allocatable :: file_restart
+
+
+      file_restart = 'fire_restart_'//trim (restart_datetime)//'.nc'
+
+    end function Build_restart_file_name
+
+    subroutine Require_restart_mpi_comm (this)
+
+      implicit none
+
+      class (state_fire_t), intent (in) :: this
+
+
+#ifdef DM_PARALLEL
+      if (.not. this%is_cfbm_comm_set) call Stop_simulation ('The MPI CFBM communicator has not been set')
+#endif
+
+    end subroutine Require_restart_mpi_comm
+
+    function Is_restart_io_root (this) result (am_root)
+
+      implicit none
+
+      class (state_fire_t), intent (in) :: this
+      logical :: am_root
+
+      integer :: rank, ierr
+
+
+#ifdef DM_PARALLEL
+      call Require_restart_mpi_comm (this)
+      call Mpi_comm_rank (this%cfbm_comm, rank, ierr)
+      if (ierr /= MPI_SUCCESS) call Stop_simulation ('Problems with Mpi_comm_rank ')
+      am_root = rank == RESTART_IO_ROOT
+#else
+      am_root = .true.
+#endif
+
+    end function Is_restart_io_root
+
+    subroutine Restart_io_barrier (this)
+
+      implicit none
+
+      class (state_fire_t), intent (in) :: this
+
+      integer :: ierr
+
+
+#ifdef DM_PARALLEL
+      call Require_restart_mpi_comm (this)
+      call MPI_Barrier (this%cfbm_comm, ierr)
+      if (ierr /= MPI_SUCCESS) call Stop_simulation ('Problems with MPI_Barrier ')
+#endif
+
+    end subroutine Restart_io_barrier
+
+    subroutine Broadcast_restart_integer (this, value)
+
+      implicit none
+
+      class (state_fire_t), intent (in) :: this
+      integer, intent (in out) :: value
+
+      integer :: ierr
+
+
+#ifdef DM_PARALLEL
+      call Require_restart_mpi_comm (this)
+      call MPI_Bcast (value, 1, MPI_INTEGER, RESTART_IO_ROOT, this%cfbm_comm, ierr)
+      if (ierr /= MPI_SUCCESS) call Stop_simulation ('Problems with MPI_Bcast for restart integer metadata')
+#endif
+
+    end subroutine Broadcast_restart_integer
+
+    subroutine Broadcast_restart_real (this, value)
+
+      implicit none
+
+      class (state_fire_t), intent (in) :: this
+      real, intent (in out) :: value
+
+      integer :: packed_value
+
+
+#ifdef DM_PARALLEL
+      packed_value = 0
+      if (Is_restart_io_root (this)) packed_value = transfer (value, packed_value)
+      call Broadcast_restart_integer (this, packed_value)
+      value = transfer (packed_value, value)
+#endif
+
+    end subroutine Broadcast_restart_real
+
+    subroutine Broadcast_restart_logical (this, value)
+
+      implicit none
+
+      class (state_fire_t), intent (in) :: this
+      logical, intent (in out) :: value
+
+      integer :: flag
+
+
+#ifdef DM_PARALLEL
+      flag = 0
+      if (Is_restart_io_root (this)) then
+        if (value) then
+          flag = 1
+        else
+          flag = 0
+        end if
+      end if
+      call Broadcast_restart_integer (this, flag)
+      value = flag /= 0
+#endif
+
+    end subroutine Broadcast_restart_logical
+
+    subroutine Broadcast_restart_failure (this, is_valid, failure_code, failure_msg)
+
+      implicit none
+
+      class (state_fire_t), intent (in) :: this
+      logical, intent (in out) :: is_valid
+      integer, intent (in out) :: failure_code
+      character (len = *), intent (in out) :: failure_msg
+
+      integer :: ierr, n, msg_len
+      integer, dimension(:), allocatable :: msg_codes
+
+
+      call Broadcast_restart_logical (this, is_valid)
+      call Broadcast_restart_integer (this, failure_code)
+#ifdef DM_PARALLEL
+      call Require_restart_mpi_comm (this)
+      msg_len = len (failure_msg)
+      allocate (msg_codes(msg_len))
+      if (Is_restart_io_root (this)) then
+        do n = 1, msg_len
+          msg_codes(n) = iachar (failure_msg(n:n))
+        end do
+      end if
+      call MPI_Bcast (msg_codes(1), msg_len, MPI_INTEGER, RESTART_IO_ROOT, this%cfbm_comm, ierr)
+      if (ierr /= MPI_SUCCESS) call Stop_simulation ('Problems with MPI_Bcast for restart failure metadata')
+      if (.not. Is_restart_io_root (this)) then
+        do n = 1, msg_len
+          failure_msg(n:n) = achar (msg_codes(n))
+        end do
+      end if
+      deallocate (msg_codes)
+#endif
+
+    end subroutine Broadcast_restart_failure
+
+    subroutine Read_restart (this, config_flags)
+
+      implicit none
+
+      class (state_fire_t), intent (in out) :: this
+      type (namelist_t), intent (in) :: config_flags
+
+      type (datetime_t) :: datetime_restart, datetime_check
+      character (len = :), allocatable :: file_restart
+      integer (kind = INT32) :: att_int, restart_year, restart_month, restart_day, restart_hour, restart_minute, restart_second, &
+          start_year, start_month, start_day, start_hour, start_minute, start_second
+      integer :: ij, expected_sr_x, expected_sr_y, ierr, rank
+      logical, parameter :: DEBUG_LOCAL = .false.
+
+
+      if (DEBUG_LOCAL) call Print_message ('Entering Read_restart...')
+
+#ifdef DM_PARALLEL
+      call Require_restart_mpi_comm (this)
+      call Mpi_comm_rank (this%cfbm_comm, rank, ierr)
+      if (ierr /= MPI_SUCCESS) call Stop_simulation ('Problems with Mpi_comm_rank ')
+#else
+      rank = 0
+#endif
+
+      if (config_flags%ideal_opt /= 0 .and. config_flags%ideal_opt /= 1) &
+          call Stop_simulation ('Read_restart is implemented for standalone idealized and real runs only')
+
+      datetime_restart = datetime_t (config_flags%start_year, config_flags%start_month, config_flags%start_day, &
+          config_flags%start_hour, config_flags%start_minute, config_flags%start_second)
+      file_restart = Build_restart_file_name (datetime_restart%datetime)
+
+      if (rank == 0) then
+        call Is_netcdf_file_present (file_restart)
+
+        call Validate_restart_integer (file_restart, 'restart_year', config_flags%start_year)
+        call Validate_restart_integer (file_restart, 'restart_month', config_flags%start_month)
+        call Validate_restart_integer (file_restart, 'restart_day', config_flags%start_day)
+        call Validate_restart_integer (file_restart, 'restart_hour', config_flags%start_hour)
+        call Validate_restart_integer (file_restart, 'restart_minute', config_flags%start_minute)
+        call Validate_restart_integer (file_restart, 'restart_second', config_flags%start_second)
+
+        call Validate_restart_integer (file_restart, 'nx', this%nx)
+        call Validate_restart_integer (file_restart, 'ny', this%ny)
+        call Validate_restart_real (file_restart, 'dt', this%dt)
+        call Validate_restart_real (file_restart, 'dx', this%dx)
+        call Validate_restart_real (file_restart, 'dy', this%dy)
+        call Validate_restart_real (file_restart, 'cen_lat', this%cen_lat)
+        call Validate_restart_real (file_restart, 'cen_lon', this%cen_lon)
+        expected_sr_x = nint (this%proj%dx / this%dx)
+        expected_sr_y = nint (this%proj%dy / this%dy)
+        call Validate_restart_integer (file_restart, 'map_proj', 1)
+        call Validate_restart_integer (file_restart, 'sr_x', expected_sr_x)
+        call Validate_restart_integer (file_restart, 'sr_y', expected_sr_y)
+        call Validate_restart_integer (file_restart, 'ideal_opt', config_flags%ideal_opt)
+        call Validate_restart_integer (file_restart, 'fuel_opt', config_flags%fuel_opt)
+        call Validate_restart_integer (file_restart, 'ros_opt', config_flags%ros_opt)
+        call Validate_restart_integer (file_restart, 'fmc_opt', config_flags%fmc_opt)
+        call Validate_restart_integer (file_restart, 'emis_opt', config_flags%emis_opt)
+        call Validate_restart_integer (file_restart, 'fire_upwinding', config_flags%fire_upwinding)
+        call Validate_restart_integer (file_restart, 'fire_upwinding_reinit', config_flags%fire_upwinding_reinit)
+        call Validate_restart_integer (file_restart, 'fire_lsm_reinit_iter', config_flags%fire_lsm_reinit_iter)
+        call Validate_restart_real (file_restart, 'fire_viscosity', config_flags%fire_viscosity)
+        call Validate_restart_real (file_restart, 'fire_viscosity_bg', config_flags%fire_viscosity_bg)
+        call Validate_restart_integer (file_restart, 'fire_viscosity_ngp', config_flags%fire_viscosity_ngp)
+        call Validate_restart_real (file_restart, 'fire_viscosity_band', config_flags%fire_viscosity_band)
+        call Validate_restart_real (file_restart, 'reinit_pseudot_coef', config_flags%reinit_pseudot_coef)
+
+        select case (config_flags%ideal_opt)
+          case (0)
+            call Validate_restart_real (file_restart, 'stand_lon', this%proj%standard_lon)
+            call Validate_restart_real (file_restart, 'true_lat_1', this%proj%true_lat_1)
+            call Validate_restart_real (file_restart, 'true_lat_2', this%proj%true_lat_2)
+
+          case (1)
+            call Validate_restart_real (file_restart, 'stand_lon', config_flags%stand_lon)
+            call Validate_restart_real (file_restart, 'true_lat_1', config_flags%true_lat_1)
+            call Validate_restart_real (file_restart, 'true_lat_2', config_flags%true_lat_2)
+        end select
+
+        call Get_netcdf_att (file_restart, 'global', 'start_year', start_year)
+        call Get_netcdf_att (file_restart, 'global', 'start_month', start_month)
+        call Get_netcdf_att (file_restart, 'global', 'start_day', start_day)
+        call Get_netcdf_att (file_restart, 'global', 'start_hour', start_hour)
+        call Get_netcdf_att (file_restart, 'global', 'start_minute', start_minute)
+        call Get_netcdf_att (file_restart, 'global', 'start_second', start_second)
+
+        call Get_netcdf_att (file_restart, 'global', 'restart_year', restart_year)
+        call Get_netcdf_att (file_restart, 'global', 'restart_month', restart_month)
+        call Get_netcdf_att (file_restart, 'global', 'restart_day', restart_day)
+        call Get_netcdf_att (file_restart, 'global', 'restart_hour', restart_hour)
+        call Get_netcdf_att (file_restart, 'global', 'restart_minute', restart_minute)
+        call Get_netcdf_att (file_restart, 'global', 'restart_second', restart_second)
+
+        call Get_netcdf_att (file_restart, 'global', 'itimestep', att_int)
+      end if
+
+      call Broadcast_restart_integer (this, start_year)
+      call Broadcast_restart_integer (this, start_month)
+      call Broadcast_restart_integer (this, start_day)
+      call Broadcast_restart_integer (this, start_hour)
+      call Broadcast_restart_integer (this, start_minute)
+      call Broadcast_restart_integer (this, start_second)
+      call Broadcast_restart_integer (this, restart_year)
+      call Broadcast_restart_integer (this, restart_month)
+      call Broadcast_restart_integer (this, restart_day)
+      call Broadcast_restart_integer (this, restart_hour)
+      call Broadcast_restart_integer (this, restart_minute)
+      call Broadcast_restart_integer (this, restart_second)
+      call Broadcast_restart_integer (this, att_int)
+      this%itimestep = att_int
+
+      this%datetime_start = datetime_t (start_year, start_month, start_day, start_hour, start_minute, start_second)
+      this%datetime_now = datetime_t (restart_year, restart_month, restart_day, restart_hour, restart_minute, restart_second)
+
+      datetime_check = this%datetime_start
+      call datetime_check%Add_seconds (this%itimestep * this%dt)
+      if (datetime_check /= this%datetime_now) call Stop_simulation ('Restart clock is inconsistent with itimestep and dt')
+
+      call Set_next_datetime_after_restart (this%datetime_next_output, config_flags%interval_output)
+      call Set_next_datetime_after_restart (this%datetime_next_atm_update, config_flags%interval_atm)
+
+      call Read_restart_field (file_restart, 'lfn', this%lfn)
+      call Read_restart_field (file_restart, 'lfn_hist', this%lfn_hist)
+      call Read_restart_field (file_restart, 'lfn_0', this%lfn_0)
+      call Read_restart_field (file_restart, 'lfn_1', this%lfn_1)
+      call Read_restart_field (file_restart, 'lfn_2', this%lfn_2)
+      call Read_restart_field (file_restart, 'lfn_s0', this%lfn_s0)
+      call Read_restart_field (file_restart, 'lfn_s1', this%lfn_s1)
+      call Read_restart_field (file_restart, 'lfn_s2', this%lfn_s2)
+      call Read_restart_field (file_restart, 'lfn_s3', this%lfn_s3)
+      call Read_restart_field (file_restart, 'lfn_out', this%lfn_out)
+      call Read_restart_field (file_restart, 'tign_g', this%tign_g)
+      call Read_restart_field (file_restart, 'fuel_frac', this%fuel_frac)
+      call Read_restart_field (file_restart, 'fire_area', this%fire_area)
+      call Read_restart_field (file_restart, 'fuel_frac_burnt_dt', this%fuel_frac_burnt_dt)
+      call Read_restart_field (file_restart, 'fgrnhfx', this%fgrnhfx)
+      call Read_restart_field (file_restart, 'fgrnqfx', this%fgrnqfx)
+      call Read_restart_field (file_restart, 'fcanhfx', this%fcanhfx)
+      call Read_restart_field (file_restart, 'fcanqfx', this%fcanqfx)
+      call Read_restart_field (file_restart, 'flame_length', this%flame_length)
+      call Read_restart_field (file_restart, 'ros', this%ros)
+      call Read_restart_field (file_restart, 'ros_front', this%ros_front)
+      call Read_restart_field (file_restart, 'emis_smoke', this%emis_smoke)
+      call Read_restart_field (file_restart, 'fmc_g', this%fmc_g)
+      call Read_restart_field (file_restart, 'fuel_load_g', this%fuel_load_g)
+      call Read_restart_field (file_restart, 'fuel_time', this%fuel_time)
+      call Read_restart_field (file_restart, 'zsf', this%zsf)
+      call Read_restart_field (file_restart, 'dzdxf', this%dzdxf)
+      call Read_restart_field (file_restart, 'dzdyf', this%dzdyf)
+      call Read_restart_field (file_restart, 'nfuel_cat', this%nfuel_cat)
+      call Read_restart_field (file_restart, 'uf', this%uf)
+      call Read_restart_field (file_restart, 'vf', this%vf)
+      call Read_restart_field (file_restart, 'fz0', this%fz0)
+
+      if (config_flags%ideal_opt == 0) then
+        call Read_restart_field (file_restart, 'fire_t2', this%fire_t2)
+        call Read_restart_field (file_restart, 'fire_q2', this%fire_q2)
+        call Read_restart_field (file_restart, 'fire_psfc', this%fire_psfc)
+        call Read_restart_field (file_restart, 'fire_rain', this%fire_rain)
+        if (config_flags%fmoist_run) then
+          call Read_restart_field (file_restart, 'fire_t2_old', this%fire_t2_old)
+          call Read_restart_field (file_restart, 'fire_q2_old', this%fire_q2_old)
+          call Read_restart_field (file_restart, 'fire_psfc_old', this%fire_psfc_old)
+          call Read_restart_field (file_restart, 'fire_rain_old', this%fire_rain_old)
+        end if
+      end if
+      if (config_flags%fmoist_run) call Read_restart_fmc (file_restart)
+
+      call Exchange_restart_halos ()
+
+      if (allocated (this%ros_param) .and. allocated (this%fuels)) then
+        do ij = 1, this%num_tiles
+          call this%ros_param%Set_params (this%ifms, this%ifme, this%jfms, this%jfme, this%i_start(ij), this%i_end(ij), &
+              this%j_start(ij), this%j_end(ij), this%fuels, this%nfuel_cat, this%fmc_g)
+        end do
+      end if
+
+      if (DEBUG_LOCAL) call Print_message ('Leaving Read_restart...')
+
+    contains
+
+      subroutine Exchange_restart_halos ()
+
+        implicit none
+
+
+#ifdef DM_PARALLEL
+        call Exchange_restart_field (this%lfn)
+        call Exchange_restart_field (this%lfn_hist)
+        call Exchange_restart_field (this%lfn_0)
+        call Exchange_restart_field (this%lfn_1)
+        call Exchange_restart_field (this%lfn_2)
+        call Exchange_restart_field (this%lfn_s0)
+        call Exchange_restart_field (this%lfn_s1)
+        call Exchange_restart_field (this%lfn_s2)
+        call Exchange_restart_field (this%lfn_s3)
+        call Exchange_restart_field (this%lfn_out)
+        call Exchange_restart_field (this%tign_g)
+        call Exchange_restart_field (this%fuel_frac)
+        call Exchange_restart_field (this%fire_area)
+        call Exchange_restart_field (this%fuel_frac_burnt_dt)
+        call Exchange_restart_field (this%fgrnhfx)
+        call Exchange_restart_field (this%fgrnqfx)
+        call Exchange_restart_field (this%fcanhfx)
+        call Exchange_restart_field (this%fcanqfx)
+        call Exchange_restart_field (this%flame_length)
+        call Exchange_restart_field (this%ros)
+        call Exchange_restart_field (this%ros_front)
+        call Exchange_restart_field (this%emis_smoke)
+        call Exchange_restart_field (this%fmc_g)
+        call Exchange_restart_field (this%fuel_load_g)
+        call Exchange_restart_field (this%fuel_time)
+        call Exchange_restart_field (this%zsf)
+        call Exchange_restart_field (this%dzdxf)
+        call Exchange_restart_field (this%dzdyf)
+        call Exchange_restart_field (this%nfuel_cat)
+        call Exchange_restart_field (this%uf)
+        call Exchange_restart_field (this%vf)
+        call Exchange_restart_field (this%fz0)
+
+        if (config_flags%ideal_opt == 0) then
+          call Exchange_restart_field (this%fire_t2)
+          call Exchange_restart_field (this%fire_q2)
+          call Exchange_restart_field (this%fire_psfc)
+          call Exchange_restart_field (this%fire_rain)
+          if (config_flags%fmoist_run) then
+            call Exchange_restart_field (this%fire_t2_old)
+            call Exchange_restart_field (this%fire_q2_old)
+            call Exchange_restart_field (this%fire_psfc_old)
+            call Exchange_restart_field (this%fire_rain_old)
+          end if
+        end if
+
+        if (config_flags%fmoist_run) call Exchange_restart_fmc_halos ()
+#endif
+
+      end subroutine Exchange_restart_halos
+
+      subroutine Exchange_restart_field (var)
+
+        implicit none
+
+        real, dimension(this%ifms:this%ifme, this%jfms:this%jfme), intent (in out) :: var
+
+
+#ifdef DM_PARALLEL
+        call Do_halo_exchange_with_corners (var, this%ifms, this%ifme, this%jfms, this%jfme, &
+            this%ifps, this%ifpe, this%jfps, this%jfpe, N_POINTS_IN_HALO, this%cart_comm)
+#endif
+
+      end subroutine Exchange_restart_field
+
+      subroutine Exchange_restart_fmc_halos ()
+
+        implicit none
+
+        integer :: k, n_moisture_classes
+
+
+#ifdef DM_PARALLEL
+        if (.not. allocated (this%fmc_param)) call Stop_simulation ('FMC restart halo exchange requires allocated fmc_param')
+
+        select type (fmc_param => this%fmc_param)
+          type is (fmc_wrffire_t)
+            if (.not. allocated (fmc_param%fmc_gc)) call Stop_simulation ('FMC restart halo exchange requires allocated fmc_gc')
+
+            n_moisture_classes = size (fmc_param%fmc_gc, 2)
+            do k = 1, n_moisture_classes
+              call Do_halo_exchange_with_corners (fmc_param%fmc_gc(this%ifms:this%ifme, k, this%jfms:this%jfme), &
+                  this%ifms, this%ifme, this%jfms, this%jfme, &
+                  this%ifps, this%ifpe, this%jfps, this%jfpe, N_POINTS_IN_HALO, this%cart_comm)
+            end do
+
+          class default
+            call Stop_simulation ('Restart halo exchange is not implemented for selected FMC component')
+        end select
+#endif
+
+      end subroutine Exchange_restart_fmc_halos
+
+      subroutine Read_restart_field (file_name, var_name, var)
+
+        implicit none
+
+        character (len = *), intent (in) :: file_name, var_name
+        real, dimension(this%ifms:this%ifme, this%jfms:this%jfme), intent (in out) :: var
+
+
+        call Get_netcdf_var_mpi (file_name, this%cfbm_comm, this%nx, this%ny, &
+            this%ifps, this%ifpe, this%jfps, this%jfpe, var_name, var(this%ifps:this%ifpe, this%jfps:this%jfpe))
+
+      end subroutine Read_restart_field
+
+      subroutine Read_restart_fmc (file_name)
+
+        implicit none
+
+        character (len = *), intent (in) :: file_name
+
+        real (kind = REAL32) :: att_real32
+        real :: fmoist_lasttime, fmoist_nexttime
+        integer :: n_moisture_classes
+
+
+        if (.not. allocated (this%fmc_param)) call Stop_simulation ('FMC restart read requires allocated fmc_param')
+
+        select type (fmc_param => this%fmc_param)
+          type is (fmc_wrffire_t)
+            if (.not. allocated (fmc_param%fmc_gc)) call Stop_simulation ('FMC restart read requires allocated fmc_gc')
+
+            n_moisture_classes = size (fmc_param%fmc_gc, 2)
+            call Get_netcdf_var_mpi (file_name, this%cfbm_comm, this%nx, this%ny, n_moisture_classes, &
+                this%ifps, this%ifpe, this%jfps, this%jfpe, NAME_VAR_FMC_GC, &
+                fmc_param%fmc_gc(this%ifps:this%ifpe, 1:n_moisture_classes, this%jfps:this%jfpe))
+
+            fmoist_lasttime = 0.0
+            fmoist_nexttime = 0.0
+            if (rank == 0) then
+              call Get_netcdf_att (file_name, 'global', NAME_ATT_FMOIST_LASTTIME, att_real32)
+              fmoist_lasttime = att_real32
+              call Get_netcdf_att (file_name, 'global', NAME_ATT_FMOIST_NEXTTIME, att_real32)
+              fmoist_nexttime = att_real32
+            end if
+            call Broadcast_restart_real (this, fmoist_lasttime)
+            call Broadcast_restart_real (this, fmoist_nexttime)
+            fmc_param%fmoist_lasttime = fmoist_lasttime
+            fmc_param%fmoist_nexttime = fmoist_nexttime
+
+          class default
+            call Stop_simulation ('Restart read is not implemented for selected FMC component')
+        end select
+
+      end subroutine Read_restart_fmc
+
+      subroutine Set_next_datetime_after_restart (datetime_next, interval_seconds)
+
+        implicit none
+
+        type (datetime_t), intent (in out) :: datetime_next
+        integer, intent (in) :: interval_seconds
+
+        datetime_next = this%datetime_now
+        if (interval_seconds > 0) then
+          datetime_next = this%datetime_start
+          do while (datetime_next <= this%datetime_now)
+            call datetime_next%Add_seconds (interval_seconds)
+          end do
+        end if
+
+      end subroutine Set_next_datetime_after_restart
+
+    end subroutine Read_restart
+
+    subroutine Read_restart_field_2d (file_name, var_name, nx, ny, ifms, ifme, jfms, jfme, ifps, ifpe, jfps, jfpe, cfbm_comm, var)
+
+      implicit none
+
+      character (len = *), intent (in) :: file_name, var_name
+      integer, intent (in) :: nx, ny, ifms, ifme, jfms, jfme, ifps, ifpe, jfps, jfpe, cfbm_comm
+      real, dimension(ifms:ifme, jfms:jfme), intent (in out) :: var
+
+
+      call Get_netcdf_var_mpi (file_name, cfbm_comm, nx, ny, ifps, ifpe, jfps, jfpe, &
+          var_name, var(ifps:ifpe, jfps:jfpe))
+
+    end subroutine Read_restart_field_2d
+
+    subroutine Validate_restart_integer (file_name, att_name, expected_value)
+
+      implicit none
+
+      character (len = *), intent (in) :: file_name, att_name
+      integer, intent (in) :: expected_value
+
+      integer (kind = INT32) :: att_value
+      character (len = :), allocatable :: msg
+
+
+      call Get_netcdf_att (file_name, 'global', att_name, att_value)
+      if (att_value /= expected_value) then
+        msg = 'Restart metadata mismatch: '//trim (att_name)
+        call Stop_simulation (msg)
+      end if
+
+    end subroutine Validate_restart_integer
+
+    subroutine Validate_restart_real (file_name, att_name, expected_value)
+
+      implicit none
+
+      character (len = *), intent (in) :: file_name, att_name
+      real, intent (in) :: expected_value
+
+      real (kind = REAL32) :: att_value, tolerance
+      character (len = :), allocatable :: msg
+
+
+      call Get_netcdf_att (file_name, 'global', att_name, att_value)
+      tolerance = max (1.0e-6_REAL32, abs (real (expected_value, kind = REAL32)) * 1.0e-6_REAL32)
+      if (abs (att_value - real (expected_value, kind = REAL32)) > tolerance) then
+        msg = 'Restart metadata mismatch: '//trim (att_name)
+        call Stop_simulation (msg)
+      end if
+
+    end subroutine Validate_restart_real
+
+    subroutine Write_restart (this, config_flags)
+
+      implicit none
+
+      class (state_fire_t), intent (in) :: this
+      type (namelist_t), intent (in) :: config_flags
+
+      character (len = :), allocatable :: file_restart
+      integer :: start_year, start_month, start_day, start_hour, start_minute, start_second, &
+          restart_year, restart_month, restart_day, restart_hour, restart_minute, restart_second
+      integer :: restart_sr_x, restart_sr_y, rank, ierr
+      logical, parameter :: DEBUG_LOCAL = .false.
+
+
+      if (DEBUG_LOCAL) call Print_message ('Entering Write_restart...')
+
+#ifdef DM_PARALLEL
+      if (.not. this%is_cfbm_comm_set) call Stop_simulation ('The MPI CFBM communicator has not been set')
+      call Mpi_comm_rank (this%cfbm_comm, rank, ierr)
+      if (ierr /= MPI_SUCCESS) call Stop_simulation ('Problems with Mpi_comm_rank ')
+#else
+      rank = 0
+#endif
+
+      if (config_flags%ideal_opt /= 0 .and. config_flags%ideal_opt /= 1) &
+          call Stop_simulation ('Write_restart is implemented for standalone idealized and real runs only')
+
+      file_restart = Build_restart_file_name (this%datetime_now%datetime)
+
+      call this%datetime_start%Get_datetime_as_ints (start_year, start_month, start_day, start_hour, start_minute, start_second)
+      call this%datetime_now%Get_datetime_as_ints (restart_year, restart_month, restart_day, restart_hour, restart_minute, restart_second)
+      restart_sr_x = nint (this%proj%dx / this%dx)
+      restart_sr_y = nint (this%proj%dy / this%dy)
+      if (restart_sr_x <= 0 .or. restart_sr_y <= 0) call Stop_simulation ('Restart subgrid ratios must be positive')
+
+      if (rank == 0) then
+        call Create_netcdf_file (file_name = file_restart)
+        call Add_netcdf_dim (file_restart, NAME_DIM_X, this%nx)
+        call Add_netcdf_dim (file_restart, NAME_DIM_Y, this%ny)
+
+        call Add_netcdf_att (file_restart, 'global', 'start_year', int (start_year, kind = INT32))
+        call Add_netcdf_att (file_restart, 'global', 'start_month', int (start_month, kind = INT32))
+        call Add_netcdf_att (file_restart, 'global', 'start_day', int (start_day, kind = INT32))
+        call Add_netcdf_att (file_restart, 'global', 'start_hour', int (start_hour, kind = INT32))
+        call Add_netcdf_att (file_restart, 'global', 'start_minute', int (start_minute, kind = INT32))
+        call Add_netcdf_att (file_restart, 'global', 'start_second', int (start_second, kind = INT32))
+        call Add_netcdf_att (file_restart, 'global', 'restart_year', int (restart_year, kind = INT32))
+        call Add_netcdf_att (file_restart, 'global', 'restart_month', int (restart_month, kind = INT32))
+        call Add_netcdf_att (file_restart, 'global', 'restart_day', int (restart_day, kind = INT32))
+        call Add_netcdf_att (file_restart, 'global', 'restart_hour', int (restart_hour, kind = INT32))
+        call Add_netcdf_att (file_restart, 'global', 'restart_minute', int (restart_minute, kind = INT32))
+        call Add_netcdf_att (file_restart, 'global', 'restart_second', int (restart_second, kind = INT32))
+        call Add_netcdf_att (file_restart, 'global', 'itimestep', int (this%itimestep, kind = INT32))
+        call Add_netcdf_att (file_restart, 'global', 'nx', int (this%nx, kind = INT32))
+        call Add_netcdf_att (file_restart, 'global', 'ny', int (this%ny, kind = INT32))
+        call Add_netcdf_att (file_restart, 'global', 'dt', real (this%dt, kind = REAL32))
+        call Add_netcdf_att (file_restart, 'global', 'dx', real (this%dx, kind = REAL32))
+        call Add_netcdf_att (file_restart, 'global', 'dy', real (this%dy, kind = REAL32))
+        call Add_netcdf_att (file_restart, 'global', 'cen_lat', real (this%cen_lat, kind = REAL32))
+        call Add_netcdf_att (file_restart, 'global', 'cen_lon', real (this%cen_lon, kind = REAL32))
+        call Add_netcdf_att (file_restart, 'global', 'map_proj', int (1, kind = INT32))
+        call Add_netcdf_att (file_restart, 'global', 'sr_x', int (restart_sr_x, kind = INT32))
+        call Add_netcdf_att (file_restart, 'global', 'sr_y', int (restart_sr_y, kind = INT32))
+        call Add_netcdf_att (file_restart, 'global', 'stand_lon', real (this%proj%standard_lon, kind = REAL32))
+        call Add_netcdf_att (file_restart, 'global', 'true_lat_1', real (this%proj%true_lat_1, kind = REAL32))
+        call Add_netcdf_att (file_restart, 'global', 'true_lat_2', real (this%proj%true_lat_2, kind = REAL32))
+        call Add_netcdf_att (file_restart, 'global', 'ideal_opt', int (config_flags%ideal_opt, kind = INT32))
+        call Add_netcdf_att (file_restart, 'global', 'fuel_opt', int (config_flags%fuel_opt, kind = INT32))
+        call Add_netcdf_att (file_restart, 'global', 'ros_opt', int (config_flags%ros_opt, kind = INT32))
+        call Add_netcdf_att (file_restart, 'global', 'fmc_opt', int (config_flags%fmc_opt, kind = INT32))
+        call Add_netcdf_att (file_restart, 'global', 'emis_opt', int (config_flags%emis_opt, kind = INT32))
+        call Add_netcdf_att (file_restart, 'global', 'fire_upwinding', int (config_flags%fire_upwinding, kind = INT32))
+        call Add_netcdf_att (file_restart, 'global', 'fire_upwinding_reinit', int (config_flags%fire_upwinding_reinit, kind = INT32))
+        call Add_netcdf_att (file_restart, 'global', 'fire_lsm_reinit_iter', int (config_flags%fire_lsm_reinit_iter, kind = INT32))
+        call Add_netcdf_att (file_restart, 'global', 'fire_viscosity', real (config_flags%fire_viscosity, kind = REAL32))
+        call Add_netcdf_att (file_restart, 'global', 'fire_viscosity_bg', real (config_flags%fire_viscosity_bg, kind = REAL32))
+        call Add_netcdf_att (file_restart, 'global', 'fire_viscosity_ngp', int (config_flags%fire_viscosity_ngp, kind = INT32))
+        call Add_netcdf_att (file_restart, 'global', 'fire_viscosity_band', real (config_flags%fire_viscosity_band, kind = REAL32))
+        call Add_netcdf_att (file_restart, 'global', 'reinit_pseudot_coef', real (config_flags%reinit_pseudot_coef, kind = REAL32))
+      end if
+
+      call Restart_io_barrier (this)
+
+      call Add_restart_field ('lfn', this%lfn)
+      call Add_restart_field ('lfn_hist', this%lfn_hist)
+      call Add_restart_field ('lfn_0', this%lfn_0)
+      call Add_restart_field ('lfn_1', this%lfn_1)
+      call Add_restart_field ('lfn_2', this%lfn_2)
+      call Add_restart_field ('lfn_s0', this%lfn_s0)
+      call Add_restart_field ('lfn_s1', this%lfn_s1)
+      call Add_restart_field ('lfn_s2', this%lfn_s2)
+      call Add_restart_field ('lfn_s3', this%lfn_s3)
+      call Add_restart_field ('lfn_out', this%lfn_out)
+      call Add_restart_field ('tign_g', this%tign_g)
+      call Add_restart_field ('fuel_frac', this%fuel_frac)
+      call Add_restart_field ('fire_area', this%fire_area)
+      call Add_restart_field ('fuel_frac_burnt_dt', this%fuel_frac_burnt_dt)
+      call Add_restart_field ('fgrnhfx', this%fgrnhfx)
+      call Add_restart_field ('fgrnqfx', this%fgrnqfx)
+      call Add_restart_field ('fcanhfx', this%fcanhfx)
+      call Add_restart_field ('fcanqfx', this%fcanqfx)
+      call Add_restart_field ('flame_length', this%flame_length)
+      call Add_restart_field ('ros', this%ros)
+      call Add_restart_field ('ros_front', this%ros_front)
+      call Add_restart_field ('emis_smoke', this%emis_smoke)
+      call Add_restart_field ('fmc_g', this%fmc_g)
+      call Add_restart_field ('fuel_load_g', this%fuel_load_g)
+      call Add_restart_field ('fuel_time', this%fuel_time)
+      call Add_restart_field ('zsf', this%zsf)
+      call Add_restart_field ('dzdxf', this%dzdxf)
+      call Add_restart_field ('dzdyf', this%dzdyf)
+      call Add_restart_field ('nfuel_cat', this%nfuel_cat)
+      call Add_restart_field ('uf', this%uf)
+      call Add_restart_field ('vf', this%vf)
+      call Add_restart_field ('fz0', this%fz0)
+
+      if (config_flags%ideal_opt == 0) then
+        call Add_restart_field ('fire_t2', this%fire_t2)
+        call Add_restart_field ('fire_q2', this%fire_q2)
+        call Add_restart_field ('fire_psfc', this%fire_psfc)
+        call Add_restart_field ('fire_rain', this%fire_rain)
+        if (config_flags%fmoist_run) then
+          call Add_restart_field ('fire_t2_old', this%fire_t2_old)
+          call Add_restart_field ('fire_q2_old', this%fire_q2_old)
+          call Add_restart_field ('fire_psfc_old', this%fire_psfc_old)
+          call Add_restart_field ('fire_rain_old', this%fire_rain_old)
+        end if
+      end if
+      if (config_flags%fmoist_run) call Write_restart_fmc ()
+
+      call Restart_io_barrier (this)
+
+      if (DEBUG_LOCAL) call Print_message ('Leaving Write_restart...')
+
+    contains
+
+      subroutine Add_restart_field (var_name, var)
+
+        implicit none
+
+        character (len = *), intent (in) :: var_name
+        real, dimension(this%ifms:this%ifme, this%jfms:this%jfme), intent (in) :: var
+
+
+        call Add_netcdf_var_mpi (file_restart, this%cfbm_comm, this%nx, this%ny, this%ifps, this%ifpe, this%jfps, this%jfpe, &
+            var_name, var(this%ifps:this%ifpe, this%jfps:this%jfpe))
+
+      end subroutine Add_restart_field
+
+      subroutine Write_restart_fmc ()
+
+        implicit none
+
+        character (len = 32), dimension(3) :: dim_names_fmc_gc
+        integer :: n_moisture_classes
+
+
+        if (.not. allocated (this%fmc_param)) call Stop_simulation ('FMC restart write requires allocated fmc_param')
+
+        select type (fmc_param => this%fmc_param)
+          type is (fmc_wrffire_t)
+            if (.not. allocated (fmc_param%fmc_gc)) call Stop_simulation ('FMC restart write requires allocated fmc_gc')
+
+            n_moisture_classes = size (fmc_param%fmc_gc, 2)
+            if (rank == 0) call Add_netcdf_dim (file_restart, NAME_DIM_MOISTURE_CLASS, n_moisture_classes)
+            call Restart_io_barrier (this)
+
+            dim_names_fmc_gc(1) = NAME_DIM_X
+            dim_names_fmc_gc(2) = NAME_DIM_MOISTURE_CLASS
+            dim_names_fmc_gc(3) = NAME_DIM_Y
+            call Add_netcdf_var_mpi (file_restart, dim_names_fmc_gc, this%cfbm_comm, this%nx, this%ny, n_moisture_classes, &
+                this%ifps, this%ifpe, this%jfps, this%jfpe, NAME_VAR_FMC_GC, &
+                fmc_param%fmc_gc(this%ifps:this%ifpe, 1:n_moisture_classes, this%jfps:this%jfpe))
+
+            if (rank == 0) then
+              call Add_netcdf_att (file_restart, 'global', NAME_ATT_FMOIST_LASTTIME, &
+                  real (fmc_param%fmoist_lasttime, kind = REAL32))
+              call Add_netcdf_att (file_restart, 'global', NAME_ATT_FMOIST_NEXTTIME, &
+                  real (fmc_param%fmoist_nexttime, kind = REAL32))
+            end if
+
+          class default
+            call Stop_simulation ('Restart write is not implemented for selected FMC component')
+        end select
+
+      end subroutine Write_restart_fmc
+
+    end subroutine Write_restart
 
     subroutine Save_state (this)
 


### PR DESCRIPTION
## Description of changes:

The CFBM has had no way to stop a simulation and resume it.
This feature adds a restart capability. A run can write its dynamic fire state to a
NetCDF file at a fixed interval, and a later run can be initialized from one of
those files instead of a cold start. It covers standalone runs, serial and MPI,
and runs coupled to WRF.

Two options are added to the `&time` namelist block:

| Option | Type | Default | Meaning |
| --- | --- | --- | --- |
| `restart` | logical | `.false.` | Resume from `fire_restart_<start datetime>.nc` |
| `restart_interval` | integer | `-1` | Restart write interval in seconds; `-1` disables writes |

Both default to the previous behavior, so existing namelists are unaffected.

Changes by file:

- **`state/state_mod.F90`** carries the `Read_restart` and `Write_restart`
  type-bound methods, `Build_restart_file_name`, and the MPI helpers they need.
  A restart read validates the grid metadata stored in the file against the
  current configuration before touching any state, so a mismatched restart file
  fails early with a message instead of producing a silently wrong run.
- **`io/netcdf_mod.F90`** adds attribute writers (`Add_netcdf_att`) and
  MPI-aware readers and writers for distributed 2D and 3D fields.
- **`driver/initialize_mod.F90`** routes the real-case restart path through a
  new `Init_fire_state_from_restart`, leaving the existing geogrid
  initialization untouched. The WRF-coupled path reads the restart after the
  fire components are initialized.
- **`driver/fire_behavior.F90`** reads the restart state at startup in place of
  `Save_state`, and writes a restart every `restart_interval` seconds.
  `restart_interval` must map to a whole number of time steps or the run stops
  with a message.
- **`io/namelist_mod.F90`** adds the two options, their broadcast, and a range
  check.
- **`physics/fmc_wrffire_mod.F90`** drops its unused `state_mod` and
  `namelist_mod` imports. This one is load-bearing rather than cosmetic:
  `state_mod` now uses `fmc_wrffire_mod` for the moisture restart fields, so
  leaving those imports in place would create a circular module dependency.

### Type of change

- [X] New feature (non-breaking change which adds functionality)

## Tests conducted:

All testing on Derecho (NCAR) using the repository environment
`env/derecho/gnu-12.2.0`: GCC 12.2.0, cray-mpich 8.1.25, NetCDF-Fortran 4.9.2,
HDF5 1.12.2, ESMF 8.5.0, CMake 3.26.3.

**Builds.** Three configurations, all clean with no errors or new warnings:
serial (`--mpi-off`), MPI (default), and `--esmx` (which includes NUOPC).

**Registered ctest suite**, run on the `--esmx` build so every registered case
is reachable:

| test7 | test8 | test7esmf | test8esmf | test7esmx | test8esmx | testx |
| --- | --- | --- | --- | --- | --- | --- |
| pass | pass | pass | pass | pass | pass | pass |

7 of 7. The NUOPC cases matter here because the cap uses both `initialize_mod`
and `state_mod`, and this PR touches both.

**Restart regressions.** These run a case straight through, then run it again
stopping and restarting partway, and compare the two. Restart test scripts are
not included in this PR (see below), but the results are:

Serial build, 20 of 20 checks:

| test7_restart | test8_restart | test9 | test9_restart |
| --- | --- | --- | --- |
| 5/5 | 5/5 | 5/5 | 5/5 |

MPI build on a compute node, 30 of 30 checks:

| ranks | test7_restart | test8_restart |
| --- | --- | --- |
| 1 | 5/5 | 5/5 |
| 2 | 5/5 | 5/5 |
| 4 | 5/5 | 5/5 |

The multi-rank runs are the ones that exercise the distributed restart read and
write and the halo exchange following a restart read. Restarting at 2 and 4
ranks reproduces the continuous run, so the domain decomposition is handled
correctly on the restart path.

57 passing checks in total across the three build configurations.

**Not covered.** Two gaps, stated explicitly:

1. The WRF-coupled restart path (`Init_fire_state_within_wrf` calling
   `Read_restart`) is exercised by a separate WRF harness, and not tested here.
2. Rank counts above 4 have not been tried.

**On the test scripts.** The restart test scripts (`test7_restart.s`,
`test8_restart.s`, `test9.s`, `test9_restart.s`, the `test9` case directory, and
the `tests/CMakeLists.txt` registration) are deliberately held out of this PR
pending the separate discussion about how tests should be organized. They are
ready and can be added here or in a follow-up PR, whichever is preferred.

## Documentation:

- [ ] Documentation has been updated for these changes
- [ ] No documentation update needed

Documentation was left out to keep the diff focused on
the code. Happy to add it to this PR if preferred, otherwise it will follow
separately.

## Contributors:

@masih-e (Masih Eghdami:masih@ucar.edu)
@mefrediani (Maria Frediani:frediani@ucar.edu)

LLM/coding assistant technology used: the restart implementation was developed
with assistance from Codex GPT-5.5 and Claude Opus 4.7. Claude Opus 5 assisted
with the pre-review cleanup of this branch.

## Further information:

`state/state_mod.F90` grows from 1063 to 1965 lines in this PR, which is more
than that file should carry. A restart-specific module is worth doing as a follow-up. This 
change is not possible with the current code because the restart calls depend on the fire
state type. 
